### PR TITLE
Upgrade blog tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@
   - [ ] provide a mapping for some, e.g. reactjs maps to react, ReactJS, react.js, ...
   - [ ] sluggify all tags, React => react, React Native => react-native, ...
   - [ ] create one page per tag slug only
-  - [ ] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits  
+  - [ ] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits
+    - [ ] refactor blog tags to use the new tag object, with `value` prop, etc. (mainly to learn how the grouping is done currently and adapt for tidbits later)
 - [ ] why is there no tags and months left sidebar on the tidbits page?
 
 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 - [x] remove using pico-tester, since mocha is the better alternative and it is fast
 - [x] use `{strict as assert}`
 - [ ] ensure proper URLs from tags, e.g. currently there is /blog/tag/JavaScript and /blog/tag/javascript and same with "react native" and "reactnative", etc.
+  - [ ] provide a mapping for some, e.g. reactjs maps to react, ReactJS, react.js, ...
+  - [ ] sluggify all tags, React => react, React Native => react-native, ...
+  - [ ] create one page per tag slug only
+  - [ ] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits  
 - [ ] why is there no tags and months left sidebar on the tidbits page?
 
 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@
   - [ ] sluggify all tags, React => react, React Native => react-native, ...
   - [ ] create one page per tag slug only
   - [ ] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits
-    - [ ] refactor blog tags to use the new tag object, with `value` prop, etc. (mainly to learn how the grouping is done currently and adapt for tidbits later)
-      - [ ] use the slugs to group by tags
+    - [x] refactor blog tags to use the new tag object, with `value` prop, etc. (mainly to learn how the grouping is done currently and adapt for tidbits later)
+      - [x] use the slugs to group by tags
         - [x] add slugs to blog tags
     - [ ] add tests to verify rendering the tpls, like in tidbits
     - [ ] render tag pages using slugs (not the tag itself anymore)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@
   - [ ] create one page per tag slug only
   - [ ] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits
     - [ ] refactor blog tags to use the new tag object, with `value` prop, etc. (mainly to learn how the grouping is done currently and adapt for tidbits later)
+      - [ ] use the slugs to group by tags
+        - [x] add slugs to blog tags
     - [ ] add tests to verify rendering the tpls, like in tidbits
+    - [ ] render tag pages using slugs (not the tag itself anymore)
 - [ ] why is there no tags and months left sidebar on the tidbits page?
 
 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,16 +31,27 @@
         left space stays empty
 - [x] remove using pico-tester, since mocha is the better alternative and it is fast
 - [x] use `{strict as assert}`
-- [ ] ensure proper URLs from tags, e.g. currently there is /blog/tag/JavaScript and /blog/tag/javascript and same with "react native" and "reactnative", etc.
-  - [ ] provide a mapping for some, e.g. reactjs maps to react, ReactJS, react.js, ...
-  - [ ] sluggify all tags, React => react, React Native => react-native, ...
-  - [ ] create one page per tag slug only
-  - [ ] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits
+- [x] refactor tags to be slugs when used as URL and to create pages    
+  - [x] sluggify all tags, React => react, React Native => react-native, ...
+  - [x] create one page per tag slug only
+  - [x] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits
     - [x] refactor blog tags to use the new tag object, with `value` prop, etc. (mainly to learn how the grouping is done currently and adapt for tidbits later)
       - [x] use the slugs to group by tags
         - [x] add slugs to blog tags
-    - [ ] add tests to verify rendering the tpls, like in tidbits
-    - [ ] render tag pages using slugs (not the tag itself anymore)
+    - [x] add tests to verify rendering the tpls, like in tidbits
+    - [x] render tag pages using slugs (not the tag itself anymore)
+- [ ] show tags for tidbits overview page
+  - [ ] show tags as on blog page
+  - [ ] multiple views with tags:
+    - [ ] tabs: top-tags, alphabetical
+    - [ ] show: 10 or all tags 
+    - [ ] show bar in bg with amount of tags
+- [ ] solidify tag usage
+  - [ ] aliases: map multiple (same) tags to one slug, 
+        e.g. js, javascript, JavaScript => javascript
+        or: jscc, jscc17, jscc20 => JSCraftCamp
+       (see the genreated pages)
+  - [ ] enhance: generate additional tags, e.g. if "ruby" is given also add "programming language"
 - [ ] why is there no tags and months left sidebar on the tidbits page?
 
 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   - [ ] create one page per tag slug only
   - [ ] store tag-object and provide tag: slug, value, ... extend the current tag object that exists in tidbits
     - [ ] refactor blog tags to use the new tag object, with `value` prop, etc. (mainly to learn how the grouping is done currently and adapt for tidbits later)
+    - [ ] add tests to verify rendering the tpls, like in tidbits
 - [ ] why is there no tags and months left sidebar on the tidbits page?
 
 # v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.1.0",
@@ -285,7 +288,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/commander": {
       "version": "5.1.0",
@@ -302,12 +308,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -341,6 +350,9 @@
         "mime": "^1.6.0",
         "minimist": "^1.1.0",
         "url-join": "^2.0.5"
+      },
+      "bin": {
+        "ecstatic": "lib/ecstatic.js"
       }
     },
     "node_modules/emoji-regex": {
@@ -381,9 +393,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "node_modules/fill-range": {
@@ -420,12 +432,23 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
       "dev": true,
-      "dependencies": {
-        "debug": "^3.0.0"
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -530,6 +553,9 @@
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-server": {
@@ -548,6 +574,13 @@
         "portfinder": "^1.0.25",
         "secure-compare": "3.0.1",
         "union": "~0.5.0"
+      },
+      "bin": {
+        "hs": "bin/http-server",
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/inflight": {
@@ -677,7 +710,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -704,6 +743,9 @@
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mocha": {
@@ -812,10 +854,13 @@
       }
     },
     "node_modules/opener": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
-      "dev": true
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -880,21 +925,30 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "node_modules/portfinder": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
-      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
       "dev": true,
       "dependencies": {
         "async": "^2.6.2",
         "debug": "^3.1.1",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.5"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
       }
     },
     "node_modules/qs": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -1063,6 +1117,9 @@
       "dev": true,
       "dependencies": {
         "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/url-join": {
@@ -1624,9 +1681,9 @@
       "dev": true
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
@@ -1681,9 +1738,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "fill-range": {
@@ -1711,13 +1768,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2028,9 +2082,9 @@
       }
     },
     "opener": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
     },
     "p-limit": {
@@ -2075,14 +2129,14 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "portfinder": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
-      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
         "debug": "^3.1.1",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.5"
       }
     },
     "qs": {

--- a/src/_shared/slug.js
+++ b/src/_shared/slug.js
@@ -1,0 +1,3 @@
+import * as marked from "marked";
+
+export const slug = s => new marked.Slugger().slug(s);

--- a/src/_shared/slug.js
+++ b/src/_shared/slug.js
@@ -1,3 +1,7 @@
 import * as marked from "marked";
 
+/**
+ * @param s {string}
+ * @return {string}
+ */
 export const slug = s => new marked.Slugger().slug(s);

--- a/src/blog-post/BlogPost.d.ts
+++ b/src/blog-post/BlogPost.d.ts
@@ -1,28 +1,45 @@
+import {BlogPostSourceFile} from "./BlogPostSourceFile";
+
+export type RawBlogPost = {
+  abstract: string;
+  abstractAsHtml: string;
+  bodyAsHtml: string;
+  hasAbstractOnly: boolean;
+  headline: string;
+  headlineAsHtml: string;
+};
+
 export type BlogPostMetadata = {
   canonicalUrl: string;
+  canonicalHint: string;
   dateCreated: DateString | DateTimeString;
   isDraft: boolean;
   oldUrls: string[];
   previewImage: string;
   tags: string[];
-}
+  vimeoId?: string;
+  videoStartTime?: string;
+  youtubeId?: string;
+};
 
 export class BlogPost {
-  abstract: string;
-  abstractAsHtml: string;
-  bodyAsHtml: string;
+  private _dateCreated: BlogPostMetadata['dateCreated'];
+  abstract: RawBlogPost['abstract'];
+  abstractAsHtml: RawBlogPost['abstractAsHtml'];
+  bodyAsHtml: RawBlogPost['bodyAsHtml'];
   canonicalUrl: BlogPostMetadata['canonicalUrl'];
+  canonicalHint: BlogPostMetadata['canonicalHint'];
   dateCreated: BlogPostMetadata['dateCreated'];
   hasVideo: boolean;
   isDraft: BlogPostMetadata['isDraft'];
   markdownFilename: Filename;
   oldUrls:  BlogPostMetadata['oldUrls'];
   tags:  BlogPostMetadata['tags'];
-  previewImageUrl: string;
+  previewImageUrl: BlogPostMetadata['previewImage'];
   url: string;
-  vimeoId?: string;
-  videoStartTime?: string;
-  youtubeId?: string;
+  vimeoId?: BlogPostMetadata['vimeoId'];
+  videoStartTime?: BlogPostMetadata['videoStartTime'];
+  youtubeId?: BlogPostMetadata['youtubeId'];
 
-  static preload(markdownFilename: string): BlogPost;
+  static withSourceFile(blogPostSourceFile: BlogPostSourceFile, rawBlogPostData: RawBlogPost): BlogPost;
 }

--- a/src/blog-post/BlogPost.d.ts
+++ b/src/blog-post/BlogPost.d.ts
@@ -34,7 +34,7 @@ export class BlogPost {
   isDraft: BlogPostMetadata['isDraft'];
   markdownFilename: Filename;
   oldUrls:  BlogPostMetadata['oldUrls'];
-  tags:  BlogPostMetadata['tags'];
+  tags:  Tag[];
   previewImageUrl: BlogPostMetadata['previewImage'];
   url: string;
   vimeoId?: BlogPostMetadata['vimeoId'];

--- a/src/blog-post/BlogPost.d.ts
+++ b/src/blog-post/BlogPost.d.ts
@@ -42,4 +42,5 @@ export class BlogPost {
   youtubeId?: BlogPostMetadata['youtubeId'];
 
   static withSourceFile(blogPostSourceFile: BlogPostSourceFile, rawBlogPostData: RawBlogPost): BlogPost;
+  static withRawData(rawBlogPostData: RawBlogPost): BlogPost;
 }

--- a/src/blog-post/BlogPost.js
+++ b/src/blog-post/BlogPost.js
@@ -44,24 +44,34 @@ export class BlogPost {
    * @return {BlogPost}
    */
   static withSourceFile(blogPostSourceFile, rawBlogPostData) {
+    const raw = {
+      ...rawBlogPostData,
+      markdownFilename: blogPostSourceFile.filename, // should this become a BlogPostSourceFile instance?
+    };
+    return BlogPost.withRawData(raw);
+  }
+  /**
+   * @param raw {RawBlogPost}
+   * @return {BlogPost}
+   */
+  static withRawData(raw) {
     const post = new BlogPost();
-    post.markdownFilename = blogPostSourceFile.filename; // should this become a BlogPostSourceFile instance?
-    post._rawTags = rawBlogPostData.tags;
-
-    post.abstract = rawBlogPostData.abstract;
-    post.abstractAsHtml = rawBlogPostData.abstractAsHtml;
-    post.bodyAsHtml = rawBlogPostData.bodyAsHtml;
-    post.canonicalHint = rawBlogPostData.canonicalHint;
-    post.canonicalUrl = rawBlogPostData.canonicalUrl;
-    post.dateCreated = rawBlogPostData.dateCreated;
-    post.headline = rawBlogPostData.headline;
-    post.headlineAsHtml = rawBlogPostData.headlineAsHtml;
-    post.isDraft = rawBlogPostData.isDraft;
-    post.oldUrls = rawBlogPostData.oldUrls;
-    post.previewImage = rawBlogPostData.previewImage;
-    post.vimeoId = rawBlogPostData.vimeoId;
-    post.videoStartTime = rawBlogPostData.videoStartTime;
-    post.youtubeId = rawBlogPostData.youtubeId;
+    post._rawTags = raw.tags;
+    post.abstract = raw.abstract;
+    post.abstractAsHtml = raw.abstractAsHtml;
+    post.bodyAsHtml = raw.bodyAsHtml;
+    post.canonicalHint = raw.canonicalHint;
+    post.canonicalUrl = raw.canonicalUrl;
+    post.dateCreated = raw.dateCreated;
+    post.headline = raw.headline;
+    post.headlineAsHtml = raw.headlineAsHtml;
+    post.markdownFilename = raw.markdownFilename;
+    post.isDraft = raw.isDraft;
+    post.oldUrls = raw.oldUrls;
+    post.previewImage = raw.previewImage;
+    post.vimeoId = raw.vimeoId;
+    post.videoStartTime = raw.videoStartTime;
+    post.youtubeId = raw.youtubeId;
     return post;
   }
   /**

--- a/src/blog-post/BlogPost.js
+++ b/src/blog-post/BlogPost.js
@@ -39,7 +39,22 @@ export class BlogPost {
   static withSourceFile(blogPostSourceFile, rawBlogPostData) {
     const post = new BlogPost();
     post.markdownFilename = blogPostSourceFile.filename; // should this become a BlogPostSourceFile instance?
-    Object.entries(rawBlogPostData).forEach(([key, value]) => post[key] = value);
+
+    post.abstract = rawBlogPostData.abstract;
+    post.abstractAsHtml = rawBlogPostData.abstractAsHtml;
+    post.bodyAsHtml = rawBlogPostData.bodyAsHtml;
+    post.canonicalHint = rawBlogPostData.canonicalHint;
+    post.canonicalUrl = rawBlogPostData.canonicalUrl;
+    post.dateCreated = rawBlogPostData.dateCreated;
+    post.headline = rawBlogPostData.headline;
+    post.headlineAsHtml = rawBlogPostData.headlineAsHtml;
+    post.isDraft = rawBlogPostData.isDraft;
+    post.oldUrls = rawBlogPostData.oldUrls;
+    post.previewImage = rawBlogPostData.previewImage;
+    post.tags = rawBlogPostData.tags;
+    post.vimeoId = rawBlogPostData.vimeoId;
+    post.videoStartTime = rawBlogPostData.videoStartTime;
+    post.youtubeId = rawBlogPostData.youtubeId;
     return post;
   }
   /**

--- a/src/blog-post/BlogPost.js
+++ b/src/blog-post/BlogPost.js
@@ -36,6 +36,11 @@ const urlForMonthFromMarkdownFilename = (markdownFilename) => {
 };
 
 export class BlogPost {
+  /**
+   * @param blogPostSourceFile {BlogPostSourceFile}
+   * @param rawBlogPostData {RawBlogPost}
+   * @return {BlogPost}
+   */
   static withSourceFile(blogPostSourceFile, rawBlogPostData) {
     const post = new BlogPost();
     post.markdownFilename = blogPostSourceFile.filename; // should this become a BlogPostSourceFile instance?

--- a/src/blog-post/BlogPost.js
+++ b/src/blog-post/BlogPost.js
@@ -2,6 +2,8 @@
  * @param {Filename} markdownFilename
  * @return {Filename}
  */
+import {slug} from "../_shared/slug.js";
+
 const dateDirectoryAndFilename = markdownFilename => markdownFilename.match(/\d{4}\/\d{2}\/\d{2}-.*/)[0];
 /**
  * @param {string} s
@@ -96,6 +98,6 @@ export class BlogPost {
     this._dateCreated = dateCreated;
   }
   get tags() {
-    return this._rawTags.map(t => ({value: t}));
+    return this._rawTags.map(t => ({value: t, slug: slug(t)}));
   }
 }

--- a/src/blog-post/BlogPost.js
+++ b/src/blog-post/BlogPost.js
@@ -44,6 +44,7 @@ export class BlogPost {
   static withSourceFile(blogPostSourceFile, rawBlogPostData) {
     const post = new BlogPost();
     post.markdownFilename = blogPostSourceFile.filename; // should this become a BlogPostSourceFile instance?
+    post._rawTags = rawBlogPostData.tags;
 
     post.abstract = rawBlogPostData.abstract;
     post.abstractAsHtml = rawBlogPostData.abstractAsHtml;
@@ -56,7 +57,6 @@ export class BlogPost {
     post.isDraft = rawBlogPostData.isDraft;
     post.oldUrls = rawBlogPostData.oldUrls;
     post.previewImage = rawBlogPostData.previewImage;
-    post.tags = rawBlogPostData.tags;
     post.vimeoId = rawBlogPostData.vimeoId;
     post.videoStartTime = rawBlogPostData.videoStartTime;
     post.youtubeId = rawBlogPostData.youtubeId;
@@ -94,5 +94,8 @@ export class BlogPost {
   }
   set dateCreated(dateCreated) {
     this._dateCreated = dateCreated;
+  }
+  get tags() {
+    return this._rawTags.map(t => ({value: t}));
   }
 }

--- a/src/blog-post/BlogPostSourceFile.d.ts
+++ b/src/blog-post/BlogPostSourceFile.d.ts
@@ -1,0 +1,6 @@
+export class BlogPostSourceFile {
+  dateCreated: DateString | DateTimeString;
+  filename: Filename;
+
+  static withFilename(filename: Filename): BlogPostSourceFile;
+}

--- a/src/blog-post/BlogPostSourceFile.js
+++ b/src/blog-post/BlogPostSourceFile.js
@@ -21,9 +21,9 @@ export class BlogPostSourceFile {
    * @return {BlogPostSourceFile}
    */
   static withFilename(filename) {
-    const blogPost = new BlogPostSourceFile();
-    blogPost.filename = filename;
-    return blogPost;
+    const sourceFile = new BlogPostSourceFile();
+    sourceFile.filename = filename;
+    return sourceFile;
   }
   get dateCreated() {
     return dateCreatedFromFilename(this.filename);

--- a/src/blog-post/group-blog-posts.js
+++ b/src/blog-post/group-blog-posts.js
@@ -12,6 +12,25 @@ export const groupBlogPostsByTag = (posts) => {
       {tag: posts[0].tags[0], blogPosts: posts}
     ]
   }
+  if (posts.length === 2 && posts[0].tags.length === 2) {
+    return [
+      {tag: posts[0].tags[0], blogPosts: posts},
+      {tag: posts[0].tags[1], blogPosts: posts},
+    ]
+  }
+  if (posts.length === 2) {
+    return [
+      {tag: posts[0].tags[0], blogPosts: [posts[0]]},
+      {tag: posts[1].tags[0], blogPosts: [posts[1]]},
+    ]
+  }
+  if (posts.length === 3) {
+    return [
+      {tag: posts[0].tags[2], blogPosts: posts},
+      {tag: posts[0].tags[1], blogPosts: [posts[0], posts[1]]},
+      {tag: posts[0].tags[0], blogPosts: [posts[0]]},
+    ]
+  }
 
   const allTags = uniques(posts.map(post => post.tags).flat());
   return allTags

--- a/src/blog-post/group-blog-posts.js
+++ b/src/blog-post/group-blog-posts.js
@@ -1,6 +1,6 @@
-const postsByTag = (posts, tag) => posts.filter(post => post.tags.includes(tag));
+const postsByTag = (posts, tagSlug) => posts.filter(post => post.tags.map(t => t.slug).includes(tagSlug));
 
-const blogPostsGroupedByTag = (tag, posts) => ({tag, blogPosts: postsByTag(posts, tag)});
+const blogPostsGroupedByTag = (tagSlug, posts) => ({tagSlug, blogPosts: postsByTag(posts, tagSlug)});
 
 const uniques = arr => [...new Set(arr)];
 
@@ -8,27 +8,29 @@ const byBlogPostsCount = (group1, group2) => group1.blogPosts.length > group2.bl
 
 export const groupBlogPostsByTag = (posts) => {
   if (posts.length === 1) {
-    return [
-      {tag: posts[0].tags[0], blogPosts: posts}
-    ]
+    const allTagsSlugs = uniques(posts.map(post => post.tags.map(t => t.slug)).flat());
+    return allTagsSlugs
+      .map(tagSlug => blogPostsGroupedByTag(tagSlug, posts))
+      .sort(byBlogPostsCount)
+    ;
   }
   if (posts.length === 2 && posts[0].tags.length === 2) {
     return [
-      {tag: posts[0].tags[0], blogPosts: posts},
-      {tag: posts[0].tags[1], blogPosts: posts},
+      {tagSlug: posts[0].tags[0].slug, blogPosts: posts},
+      {tagSlug: posts[0].tags[1].slug, blogPosts: posts},
     ]
   }
   if (posts.length === 2) {
     return [
-      {tag: posts[0].tags[0], blogPosts: [posts[0]]},
-      {tag: posts[1].tags[0], blogPosts: [posts[1]]},
+      {tagSlug: posts[0].tags[0].slug, blogPosts: [posts[0]]},
+      {tagSlug: posts[1].tags[0].slug, blogPosts: [posts[1]]},
     ]
   }
   if (posts.length === 3) {
     return [
-      {tag: posts[0].tags[2], blogPosts: posts},
-      {tag: posts[0].tags[1], blogPosts: [posts[0], posts[1]]},
-      {tag: posts[0].tags[0], blogPosts: [posts[0]]},
+      {tagSlug: posts[0].tags[2].slug, blogPosts: posts},
+      {tagSlug: posts[0].tags[1].slug, blogPosts: [posts[0], posts[1]]},
+      {tagSlug: posts[0].tags[0].slug, blogPosts: [posts[0]]},
     ]
   }
 

--- a/src/blog-post/group-blog-posts.js
+++ b/src/blog-post/group-blog-posts.js
@@ -1,13 +1,47 @@
+/**
+ * @typedef {import('./BlogPost').BlogPost} BlogPost
+ * @typedef {import('./types').BlogPostsByTag} BlogPostsByTag
+ * @typedef {import('./types').BlogPostsByYearAndMonth} BlogPostsByYearAndMonth
+ * @typedef {import('./types').YearAndMonth} YearAndMonth
+ */
+
+/**
+ * @param post {BlogPost}
+ * @return {Slug[]}
+ */
 const tagSlugsOfPost = (post) => post.tags.map(t => t.slug);
 
+/**
+ * @param posts {BlogPost[]}
+ * @param tagSlug {Slug}
+ * @return {BlogPost[]}
+ */
 const postsByTag = (posts, tagSlug) => posts.filter(post => tagSlugsOfPost(post).includes(tagSlug));
 
+/**
+ * @param tagSlug {Slug}
+ * @param posts {BlogPost[]}
+ * @return {BlogPostsByTag}
+ */
 const blogPostsGroupedByTag = (tagSlug, posts) => ({tagSlug, blogPosts: postsByTag(posts, tagSlug)});
 
+/**
+ * @param arr {string[]}
+ * @return {string[]}
+ */
 const uniques = arr => [...new Set(arr)];
 
+/**
+ * @param group1 {BlogPostsByTag}
+ * @param group2 {BlogPostsByTag}
+ * @return {number}
+ */
 const byBlogPostsCount = (group1, group2) => group1.blogPosts.length > group2.blogPosts.length ? -1 : 1;
 
+/**
+ * @param posts {BlogPost[]}
+ * @return {BlogPostsByTag[]}
+ */
 export const groupBlogPostsByTag = (posts) => {
   const allTagsSlugs = uniques(posts.map(tagSlugsOfPost).flat());
   return allTagsSlugs
@@ -16,20 +50,39 @@ export const groupBlogPostsByTag = (posts) => {
   ;
 };
 
+/**
+ * @param posts {BlogPost[]}
+ * @return {BlogPostsByYearAndMonth[]}
+ */
 export const groupBlogPostsByYearAndMonth = (posts) => {
+  /**
+   * @param map {Map<YearAndMonth, BlogPost[]>}
+   * @return {function(BlogPost): void}
+   */
   const addPostToMap = map => post => {
     const [yearLength, spaceLength, monthLength] = [4, 1, 2];
     const key = post.dateCreated.substring(0, yearLength + spaceLength + monthLength);
     if (!map.has(key)) {
       map.set(key, []);
     }
-    map.set(key, [...map.get(key), post]);
+    map.set(key, [...(/** @type {BlogPost[]} */(map.get(key))), post]);
   };
+
+  /**
+   * @param groups {BlogPostsByYearAndMonth[]}
+   * @return {function(BlogPost[], YearAndMonth): void}
+   */
   const addMapEntryToGroups = groups => (blogPosts, key) => { groups.push({yearAndMonth: key, blogPosts}); };
+
+  /**
+   * @param group1 {BlogPostsByYearAndMonth}
+   * @param group2 {BlogPostsByYearAndMonth}
+   * @return {number}
+   */
   const byYearAndMonthDesc = (group1, group2) => group1.yearAndMonth > group2.yearAndMonth ? -1 : 1;
   const mapByMonth = new Map();
   posts.forEach(addPostToMap(mapByMonth));
-  const groups = [];
+  const groups = /** @type {BlogPostsByYearAndMonth[]} */([]);
   mapByMonth.forEach(addMapEntryToGroups(groups));
   return groups.sort(byYearAndMonthDesc);
 }

--- a/src/blog-post/group-blog-posts.js
+++ b/src/blog-post/group-blog-posts.js
@@ -1,8 +1,18 @@
 const postsByTag = (posts, tag) => posts.filter(post => post.tags.includes(tag));
+
 const blogPostsGroupedByTag = (tag, posts) => ({tag, blogPosts: postsByTag(posts, tag)});
+
 const uniques = arr => [...new Set(arr)];
+
 const byBlogPostsCount = (group1, group2) => group1.blogPosts.length > group2.blogPosts.length ? -1 : 1;
+
 export const groupBlogPostsByTag = (posts) => {
+  if (posts.length === 1) {
+    return [
+      {tag: posts[0].tags[0], blogPosts: posts}
+    ]
+  }
+
   const allTags = uniques(posts.map(post => post.tags).flat());
   return allTags
     .map(tag => blogPostsGroupedByTag(tag, posts))

--- a/src/blog-post/group-blog-posts.js
+++ b/src/blog-post/group-blog-posts.js
@@ -1,4 +1,6 @@
-const postsByTag = (posts, tagSlug) => posts.filter(post => post.tags.map(t => t.slug).includes(tagSlug));
+const tagSlugsOfPost = (post) => post.tags.map(t => t.slug);
+
+const postsByTag = (posts, tagSlug) => posts.filter(post => tagSlugsOfPost(post).includes(tagSlug));
 
 const blogPostsGroupedByTag = (tagSlug, posts) => ({tagSlug, blogPosts: postsByTag(posts, tagSlug)});
 
@@ -7,36 +9,9 @@ const uniques = arr => [...new Set(arr)];
 const byBlogPostsCount = (group1, group2) => group1.blogPosts.length > group2.blogPosts.length ? -1 : 1;
 
 export const groupBlogPostsByTag = (posts) => {
-  if (posts.length === 1) {
-    const allTagsSlugs = uniques(posts.map(post => post.tags.map(t => t.slug)).flat());
-    return allTagsSlugs
-      .map(tagSlug => blogPostsGroupedByTag(tagSlug, posts))
-      .sort(byBlogPostsCount)
-    ;
-  }
-  if (posts.length === 2 && posts[0].tags.length === 2) {
-    return [
-      {tagSlug: posts[0].tags[0].slug, blogPosts: posts},
-      {tagSlug: posts[0].tags[1].slug, blogPosts: posts},
-    ]
-  }
-  if (posts.length === 2) {
-    return [
-      {tagSlug: posts[0].tags[0].slug, blogPosts: [posts[0]]},
-      {tagSlug: posts[1].tags[0].slug, blogPosts: [posts[1]]},
-    ]
-  }
-  if (posts.length === 3) {
-    return [
-      {tagSlug: posts[0].tags[2].slug, blogPosts: posts},
-      {tagSlug: posts[0].tags[1].slug, blogPosts: [posts[0], posts[1]]},
-      {tagSlug: posts[0].tags[0].slug, blogPosts: [posts[0]]},
-    ]
-  }
-
-  const allTags = uniques(posts.map(post => post.tags).flat());
-  return allTags
-    .map(tag => blogPostsGroupedByTag(tag, posts))
+  const allTagsSlugs = uniques(posts.map(tagSlugsOfPost).flat());
+  return allTagsSlugs
+    .map(tagSlug => blogPostsGroupedByTag(tagSlug, posts))
     .sort(byBlogPostsCount)
   ;
 };

--- a/src/blog-post/group-blog-posts.spec.js
+++ b/src/blog-post/group-blog-posts.spec.js
@@ -13,7 +13,7 @@ describe('Group blog posts by tags', () => {
   it('GIVEN one blog post THEN return one group', () => {
     const posts = [newPost({headline: '', tags: ['js']})];
     const grouped = groupBlogPostsByTag(posts);
-    assertThat(grouped, hasItem(hasProperties({tag: {value: 'js'}, blogPosts: posts})));
+    assertThat(grouped, hasItem(hasProperties({tag: {value: 'js', slug: 'js'}, blogPosts: posts})));
   });
   it('GIVEN two blog posts with different tags THEN return two groups', () => {
     const posts = [
@@ -22,8 +22,8 @@ describe('Group blog posts by tags', () => {
     ];
     const grouped = groupBlogPostsByTag(posts);
     assertThat(grouped, hasItems(
-      hasProperties({tag: {value: 'js'}, blogPosts: [posts[0]]}),
-      hasProperties({tag: {value: 'tdd'}, blogPosts: [posts[1]]}),
+      hasProperties({tag: {value: 'js', slug: 'js'}, blogPosts: [posts[0]]}),
+      hasProperties({tag: {value: 'tdd', slug: 'tdd'}, blogPosts: [posts[1]]}),
     ));
   });
   it('GIVEN two blog posts with the same tags each THEN return exactly two groups with each post in it', () => {
@@ -33,8 +33,8 @@ describe('Group blog posts by tags', () => {
     ];
     const grouped = groupBlogPostsByTag(posts);
     assertThat(grouped, contains(
-      hasProperties({tag: {value: 'js'}, blogPosts: posts}),
-      hasProperties({tag: {value: 'tdd'}, blogPosts: posts}),
+      hasProperties({tag: {value: 'js', slug: 'js'}, blogPosts: posts}),
+      hasProperties({tag: {value: 'tdd', slug: 'tdd'}, blogPosts: posts}),
     ));
   });
   it('GIVEN blog posts with different tags THEN return the groups sorted by the tag counts', () => {
@@ -45,9 +45,9 @@ describe('Group blog posts by tags', () => {
     ];
     const grouped = groupBlogPostsByTag(posts);
     assertThat(grouped, contains(
-      hasProperties({tag: {value: 'one'}, blogPosts: posts}),
-      hasProperties({tag: {value: 'two'}, blogPosts: [posts[0], posts[1]]}),
-      hasProperties({tag: {value: 'three'}, blogPosts: [posts[0]]}),
+      hasProperties({tag: {value: 'one', slug: 'one'}, blogPosts: posts}),
+      hasProperties({tag: {value: 'two', slug: 'two'}, blogPosts: [posts[0], posts[1]]}),
+      hasProperties({tag: {value: 'three', slug: 'three'}, blogPosts: [posts[0]]}),
     ));
   });
 });

--- a/src/blog-post/group-blog-posts.spec.js
+++ b/src/blog-post/group-blog-posts.spec.js
@@ -13,7 +13,7 @@ describe('Group blog posts by tags', () => {
   it('GIVEN one blog post THEN return one group', () => {
     const posts = [newPost({headline: '', tags: ['js']})];
     const grouped = groupBlogPostsByTag(posts);
-    assertThat(grouped, hasItem(hasProperties({tag: {value: 'js', slug: 'js'}, blogPosts: posts})));
+    assertThat(grouped, hasItem(hasProperties({tagSlug: 'js', blogPosts: posts})));
   });
   it('GIVEN two blog posts with different tags THEN return two groups', () => {
     const posts = [
@@ -22,8 +22,8 @@ describe('Group blog posts by tags', () => {
     ];
     const grouped = groupBlogPostsByTag(posts);
     assertThat(grouped, hasItems(
-      hasProperties({tag: {value: 'js', slug: 'js'}, blogPosts: [posts[0]]}),
-      hasProperties({tag: {value: 'tdd', slug: 'tdd'}, blogPosts: [posts[1]]}),
+      hasProperties({tagSlug: 'js', blogPosts: [posts[0]]}),
+      hasProperties({tagSlug: 'tdd', blogPosts: [posts[1]]}),
     ));
   });
   it('GIVEN two blog posts with the same tags each THEN return exactly two groups with each post in it', () => {
@@ -33,8 +33,8 @@ describe('Group blog posts by tags', () => {
     ];
     const grouped = groupBlogPostsByTag(posts);
     assertThat(grouped, contains(
-      hasProperties({tag: {value: 'js', slug: 'js'}, blogPosts: posts}),
-      hasProperties({tag: {value: 'tdd', slug: 'tdd'}, blogPosts: posts}),
+      hasProperties({tagSlug: 'js', blogPosts: posts}),
+      hasProperties({tagSlug: 'tdd', blogPosts: posts}),
     ));
   });
   it('GIVEN blog posts with different tags THEN return the groups sorted by the tag counts', () => {
@@ -45,9 +45,9 @@ describe('Group blog posts by tags', () => {
     ];
     const grouped = groupBlogPostsByTag(posts);
     assertThat(grouped, contains(
-      hasProperties({tag: {value: 'one', slug: 'one'}, blogPosts: posts}),
-      hasProperties({tag: {value: 'two', slug: 'two'}, blogPosts: [posts[0], posts[1]]}),
-      hasProperties({tag: {value: 'three', slug: 'three'}, blogPosts: [posts[0]]}),
+      hasProperties({tagSlug: 'one', blogPosts: posts}),
+      hasProperties({tagSlug: 'two', blogPosts: [posts[0], posts[1]]}),
+      hasProperties({tagSlug: 'three', blogPosts: [posts[0]]}),
     ));
   });
 });

--- a/src/blog-post/group-blog-posts.spec.js
+++ b/src/blog-post/group-blog-posts.spec.js
@@ -7,49 +7,49 @@ describe('Group blog posts by tags', () => {
   const newPost = ({headline, tags}) => {
     const post = new BlogPost();
     post.headline = headline;
-    post.tags = tags;
+    post._rawTags = tags; // TODO this is not really a good idea setting the private prop, is it?
     return post;
   };
   it('GIVEN one blog post THEN return one group', () => {
     const posts = [newPost({headline: '', tags: ['js']})];
     const grouped = groupBlogPostsByTag(posts);
-    assertThat(grouped, hasItem(hasProperties({tag: 'js', blogPosts: posts})));
+    assertThat(grouped, hasItem(hasProperties({tag: {value: 'js'}, blogPosts: posts})));
   });
-  it('GIVEN two blog posts with different tags THEN return two groups', () => {
-    const posts = [
-      newPost({headline: '', tags: ['js']}),
-      newPost({headline: '', tags: ['tdd']}),
-    ];
-    const grouped = groupBlogPostsByTag(posts);
-    assertThat(grouped, hasItems(
-      hasProperties({tag: 'js', blogPosts: [posts[0]]}),
-      hasProperties({tag: 'tdd', blogPosts: [posts[1]]}),
-    ));
-  });
-  it('GIVEN two blog posts with the same tags each THEN return exactly two groups with each post in it', () => {
-    const posts = [
-      newPost({headline: '', tags: ['js', 'tdd']}),
-      newPost({headline: '', tags: ['js', 'tdd']}),
-    ];
-    const grouped = groupBlogPostsByTag(posts);
-    assertThat(grouped, contains(
-      hasProperties({tag: 'js', blogPosts: posts}),
-      hasProperties({tag: 'tdd', blogPosts: posts}),
-    ));
-  });
-  it('GIVEN blog posts with different tags THEN return the groups sorted by the tag counts', () => {
-    const posts = [
-      newPost({headline: '', tags: ['three', 'two', 'one', ]}),
-      newPost({headline: '', tags: ['two', 'one', ]}),
-      newPost({headline: '', tags: ['one', ]}),
-    ];
-    const grouped = groupBlogPostsByTag(posts);
-    assertThat(grouped, contains(
-      hasProperties({tag: 'one'}),
-      hasProperties({tag: 'two'}),
-      hasProperties({tag: 'three'}),
-    ));
-  });
+  // it('GIVEN two blog posts with different tags THEN return two groups', () => {
+  //   const posts = [
+  //     newPost({headline: '', tags: ['js']}),
+  //     newPost({headline: '', tags: ['tdd']}),
+  //   ];
+  //   const grouped = groupBlogPostsByTag(posts);
+  //   assertThat(grouped, hasItems(
+  //     hasProperties({tag: 'js', blogPosts: [posts[0]]}),
+  //     hasProperties({tag: 'tdd', blogPosts: [posts[1]]}),
+  //   ));
+  // });
+  // it('GIVEN two blog posts with the same tags each THEN return exactly two groups with each post in it', () => {
+  //   const posts = [
+  //     newPost({headline: '', tags: ['js', 'tdd']}),
+  //     newPost({headline: '', tags: ['js', 'tdd']}),
+  //   ];
+  //   const grouped = groupBlogPostsByTag(posts);
+  //   assertThat(grouped, contains(
+  //     hasProperties({tag: 'js', blogPosts: posts}),
+  //     hasProperties({tag: 'tdd', blogPosts: posts}),
+  //   ));
+  // });
+  // it('GIVEN blog posts with different tags THEN return the groups sorted by the tag counts', () => {
+  //   const posts = [
+  //     newPost({headline: '', tags: ['three', 'two', 'one', ]}),
+  //     newPost({headline: '', tags: ['two', 'one', ]}),
+  //     newPost({headline: '', tags: ['one', ]}),
+  //   ];
+  //   const grouped = groupBlogPostsByTag(posts);
+  //   assertThat(grouped, contains(
+  //     hasProperties({tag: 'one'}),
+  //     hasProperties({tag: 'two'}),
+  //     hasProperties({tag: 'three'}),
+  //   ));
+  // });
 });
 
 describe('Group blog posts by year+month', () => {

--- a/src/blog-post/group-blog-posts.spec.js
+++ b/src/blog-post/group-blog-posts.spec.js
@@ -15,41 +15,41 @@ describe('Group blog posts by tags', () => {
     const grouped = groupBlogPostsByTag(posts);
     assertThat(grouped, hasItem(hasProperties({tag: {value: 'js'}, blogPosts: posts})));
   });
-  // it('GIVEN two blog posts with different tags THEN return two groups', () => {
-  //   const posts = [
-  //     newPost({headline: '', tags: ['js']}),
-  //     newPost({headline: '', tags: ['tdd']}),
-  //   ];
-  //   const grouped = groupBlogPostsByTag(posts);
-  //   assertThat(grouped, hasItems(
-  //     hasProperties({tag: 'js', blogPosts: [posts[0]]}),
-  //     hasProperties({tag: 'tdd', blogPosts: [posts[1]]}),
-  //   ));
-  // });
-  // it('GIVEN two blog posts with the same tags each THEN return exactly two groups with each post in it', () => {
-  //   const posts = [
-  //     newPost({headline: '', tags: ['js', 'tdd']}),
-  //     newPost({headline: '', tags: ['js', 'tdd']}),
-  //   ];
-  //   const grouped = groupBlogPostsByTag(posts);
-  //   assertThat(grouped, contains(
-  //     hasProperties({tag: 'js', blogPosts: posts}),
-  //     hasProperties({tag: 'tdd', blogPosts: posts}),
-  //   ));
-  // });
-  // it('GIVEN blog posts with different tags THEN return the groups sorted by the tag counts', () => {
-  //   const posts = [
-  //     newPost({headline: '', tags: ['three', 'two', 'one', ]}),
-  //     newPost({headline: '', tags: ['two', 'one', ]}),
-  //     newPost({headline: '', tags: ['one', ]}),
-  //   ];
-  //   const grouped = groupBlogPostsByTag(posts);
-  //   assertThat(grouped, contains(
-  //     hasProperties({tag: 'one'}),
-  //     hasProperties({tag: 'two'}),
-  //     hasProperties({tag: 'three'}),
-  //   ));
-  // });
+  it('GIVEN two blog posts with different tags THEN return two groups', () => {
+    const posts = [
+      newPost({headline: '', tags: ['js']}),
+      newPost({headline: '', tags: ['tdd']}),
+    ];
+    const grouped = groupBlogPostsByTag(posts);
+    assertThat(grouped, hasItems(
+      hasProperties({tag: {value: 'js'}, blogPosts: [posts[0]]}),
+      hasProperties({tag: {value: 'tdd'}, blogPosts: [posts[1]]}),
+    ));
+  });
+  it('GIVEN two blog posts with the same tags each THEN return exactly two groups with each post in it', () => {
+    const posts = [
+      newPost({headline: '', tags: ['js', 'tdd']}),
+      newPost({headline: '', tags: ['js', 'tdd']}),
+    ];
+    const grouped = groupBlogPostsByTag(posts);
+    assertThat(grouped, contains(
+      hasProperties({tag: {value: 'js'}, blogPosts: posts}),
+      hasProperties({tag: {value: 'tdd'}, blogPosts: posts}),
+    ));
+  });
+  it('GIVEN blog posts with different tags THEN return the groups sorted by the tag counts', () => {
+    const posts = [
+      newPost({headline: '', tags: ['three', 'two', 'one', ]}),
+      newPost({headline: '', tags: ['two', 'one', ]}),
+      newPost({headline: '', tags: ['one', ]}),
+    ];
+    const grouped = groupBlogPostsByTag(posts);
+    assertThat(grouped, contains(
+      hasProperties({tag: {value: 'one'}, blogPosts: posts}),
+      hasProperties({tag: {value: 'two'}, blogPosts: [posts[0], posts[1]]}),
+      hasProperties({tag: {value: 'three'}, blogPosts: [posts[0]]}),
+    ));
+  });
 });
 
 describe('Group blog posts by year+month', () => {

--- a/src/blog-post/load-blog-post.spec.js
+++ b/src/blog-post/load-blog-post.spec.js
@@ -80,7 +80,7 @@ describe('Load a blog post, with all data ready to render', () => {
       });
       it('WHEN it has the metadata `tags` THEN provide the property accordingly', async () => {
         const post = await loadPost({fileContent: `tags: tag1, tag2\n\n# headline\nabstract, yeah`});
-        assertThat(post, hasProperties({tags: ['tag1', 'tag2']}));
+        assertThat(post, hasProperties({tags: [{value: 'tag1'}, {value: 'tag2'}]}));
       });
       it('WHEN it has no `dateCreated` THEN the original dateCreated from the preloaded post is provided', async () => {
         const post = await loadPost({fileContent: `noDateCreated: :)\n\n# no dateCreated metadata`, markdownFilename: '2001/01/01-mmm.md'});

--- a/src/blog-post/load-blog-post.spec.js
+++ b/src/blog-post/load-blog-post.spec.js
@@ -80,7 +80,7 @@ describe('Load a blog post, with all data ready to render', () => {
       });
       it('WHEN it has the metadata `tags` THEN provide the property accordingly', async () => {
         const post = await loadPost({fileContent: `tags: tag1, tag2\n\n# headline\nabstract, yeah`});
-        assertThat(post, hasProperties({tags: [{value: 'tag1'}, {value: 'tag2'}]}));
+        assertThat(post, hasProperties({tags: [{value: 'tag1', slug: 'tag1'}, {value: 'tag2', slug: 'tag2'}]}));
       });
       it('WHEN it has no `dateCreated` THEN the original dateCreated from the preloaded post is provided', async () => {
         const post = await loadPost({fileContent: `noDateCreated: :)\n\n# no dateCreated metadata`, markdownFilename: '2001/01/01-mmm.md'});

--- a/src/blog-post/types.d.ts
+++ b/src/blog-post/types.d.ts
@@ -1,0 +1,6 @@
+import {BlogPost} from "./BlogPost";
+
+interface BlogPostsByTag {
+  tagSlug: Tag['slug'];
+  blogPosts: BlogPost[];
+}

--- a/src/blog-post/types.d.ts
+++ b/src/blog-post/types.d.ts
@@ -4,3 +4,10 @@ interface BlogPostsByTag {
   tagSlug: Tag['slug'];
   blogPosts: BlogPost[];
 }
+
+type YearAndMonth = string; // e.g. '2020-10'
+
+interface BlogPostsByYearAndMonth {
+  yearAndMonth: YearAndMonth;
+  blogPosts: BlogPost[];
+}

--- a/src/index.js
+++ b/src/index.js
@@ -110,15 +110,6 @@ const generateHomePage = async (posts, tidbits) => {
   await fs.promises.writeFile(destFilename, renderedFile);
 };
 
-const generateTagPage = async (group) => {
-  const tag = group.tag;
-  const destDir = path.join(OUTPUT_DIRECTORY, 'blog/tag', tag);
-  await fs.promises.mkdir(destDir, {recursive: true});
-  const destFilename = path.join(destDir, 'index.html');
-  const renderedFile = renderTemplate('blog/tag.html', {...defaultRenderParams, tag, posts: group.blogPosts});
-  await fs.promises.writeFile(destFilename, renderedFile);
-};
-
 const generateMonthPage = async (group) => {
   const yearAndMonth = group.yearAndMonth;
   const destDir = path.join(OUTPUT_DIRECTORY, 'blog', yearAndMonth.replace('-', '/'));
@@ -128,7 +119,7 @@ const generateMonthPage = async (group) => {
   await fs.promises.writeFile(destFilename, renderedFile);
 };
 
-const generateTagPages = async (postGroups) => Promise.all(postGroups.map(generateTagPage));
+const generateTagPages = (postGroups) => renderAndWriteTagPages()(postGroups, defaultRenderParams);
 const generateMonthPages = async (postGroups) => Promise.all(postGroups.map(generateMonthPage));
 
 const runAndTimeIt = async (label, fn) => {
@@ -144,6 +135,7 @@ const runAndTimeIt = async (label, fn) => {
 }
 
 import {findRelatedPosts} from './blog-post/related-posts.js';
+import {renderAndWriteTagPages} from "./render-blog/render-page.js";
 
 const isNotDraft = post => post.isDraft === false;
 const loadPosts = async sourceFiles => {

--- a/src/load-tidbit/Tidbit.d.ts
+++ b/src/load-tidbit/Tidbit.d.ts
@@ -1,9 +1,3 @@
-type Slug = string;
-type Tag = {
-  value: string;
-  slug: Slug;
-}
-
 export type RawTidbit = {
   abstract: string;
   abstractAsHtml: string;

--- a/src/load-tidbit/Tidbit.js
+++ b/src/load-tidbit/Tidbit.js
@@ -3,6 +3,10 @@ import * as marked from "marked";
 const slug = s => new marked.Slugger().slug(s);
 
 export class Tidbit {
+  /**
+   * @param raw {RawTidbit}
+   * @return {Tidbit}
+   */
   static withRawData(raw) {
     const tidbit = new Tidbit();
     tidbit.abstract = raw.abstract;

--- a/src/load-tidbit/Tidbit.js
+++ b/src/load-tidbit/Tidbit.js
@@ -1,6 +1,4 @@
-import * as marked from "marked";
-
-const slug = s => new marked.Slugger().slug(s);
+import {slug} from "../_shared/slug.js";
 
 export class Tidbit {
   /**

--- a/src/render-blog/render-page.js
+++ b/src/render-blog/render-page.js
@@ -1,0 +1,16 @@
+import {writeOutputFile} from '../_deps/fs.js';
+import {renderTemplate} from '../_deps/render-template.js';
+
+/**
+ * @param data {PlainObject}
+ * @return {string}
+ */
+const renderTagPage = (data) => renderTemplate('blog/tag.html', data);
+
+export const renderAndWriteTagPages = ({writeFile = writeOutputFile, renderPage = renderTagPage} = {}) => async (groups, renderParams) => {
+  const destFilename = tagSlug => `/blog/tag/${tagSlug}/index.html`;
+  const writeGroup = group => writeFile(destFilename(group.tagSlug), renderPage({...renderParams, tag: group.tagSlug, posts: group.blogPosts}));
+  const pageWriters = groups.map(writeGroup);
+  await Promise.all(pageWriters);
+}
+

--- a/src/render-blog/render-page.js
+++ b/src/render-blog/render-page.js
@@ -16,7 +16,7 @@ import {renderTemplate} from '../_deps/render-template.js';
 const renderTagPage = (data) => renderTemplate('blog/tag.html', data);
 
 /**
- * @param deps {TagPageProductionDependencies}
+ * @param deps? {TagPageProductionDependencies}
  * @return {function(BlogPostsByTag[], PlainObject): Promise<void>}
  */
 export const renderAndWriteTagPages = ({writeFile = writeOutputFile, renderPage = renderTagPage} = {}) => async (groups, renderParams) => {
@@ -33,4 +33,3 @@ export const renderAndWriteTagPages = ({writeFile = writeOutputFile, renderPage 
   const pageWriters = groups.map(writeGroup);
   await Promise.all(pageWriters);
 }
-

--- a/src/render-blog/render-page.js
+++ b/src/render-blog/render-page.js
@@ -2,13 +2,33 @@ import {writeOutputFile} from '../_deps/fs.js';
 import {renderTemplate} from '../_deps/render-template.js';
 
 /**
+ * @typedef {import('../blog-post/types').BlogPostsByTag} BlogPostsByTag
+ *
+ * @typedef {function(Filename, string): Promise<void>} writeFile
+ * @typedef {function(PlainObject): string} renderPage
+ * @typedef {{writeFile?: writeFile, renderPage?: renderPage}} TagPageProductionDependencies
+ */
+
+/**
  * @param data {PlainObject}
  * @return {string}
  */
 const renderTagPage = (data) => renderTemplate('blog/tag.html', data);
 
+/**
+ * @param deps {TagPageProductionDependencies}
+ * @return {function(BlogPostsByTag[], PlainObject): Promise<void>}
+ */
 export const renderAndWriteTagPages = ({writeFile = writeOutputFile, renderPage = renderTagPage} = {}) => async (groups, renderParams) => {
+  /**
+   * @param tagSlug {string}
+   * @return {string}
+   */
   const destFilename = tagSlug => `/blog/tag/${tagSlug}/index.html`;
+  /**
+   * @param group {BlogPostsByTag}
+   * @return {Promise<void>}
+   */
   const writeGroup = group => writeFile(destFilename(group.tagSlug), renderPage({...renderParams, tag: group.tagSlug, posts: group.blogPosts}));
   const pageWriters = groups.map(writeGroup);
   await Promise.all(pageWriters);

--- a/src/render-blog/render-page.slow-spec.js
+++ b/src/render-blog/render-page.slow-spec.js
@@ -1,5 +1,5 @@
 import {describe, it} from '../test.js';
-import {assertThat, containsString, hasItem, matchesPattern} from 'hamjest';
+import {assertThat, hasItem} from 'hamjest';
 import {BlogPost} from "../blog-post/BlogPost.js";
 import {renderAndWriteTagPages} from "./render-page.js";
 

--- a/src/render-blog/render-page.slow-spec.js
+++ b/src/render-blog/render-page.slow-spec.js
@@ -1,11 +1,11 @@
 import {describe, it} from '../test.js';
-import {assertThat, hasItem} from 'hamjest';
+import {assertThat, hasItem, matchesPattern, containsString} from 'hamjest';
 import {BlogPost} from "../blog-post/BlogPost.js";
 import {renderAndWriteTagPages} from "./render-page.js";
 
 // TODO THIS is really ugly, that we have to inject that every time.
 // Maybe intro a `DefaultRenderParameters.empty()` or something.
-const renderParams = {};
+const renderParams = {navigationItems: [], groupedBlogPosts: {byTag: [], byMonth: []}};
 
 const defaultRawBlogPostData = {
   abstract: '',
@@ -18,6 +18,7 @@ const defaultRawBlogPostData = {
   tags: [''],
   dateCreated: '2000-01-01 10:00 CET',
   slug: '',
+  markdownFilename: '2000/01/01-one.md',
 };
 /**
  * @param overrideData {PlainObject}
@@ -45,6 +46,67 @@ describe('Render blog pages', () => {
         await renderAndWriteTagPages({writeFile})(groups, renderParams);
         assertThat(writtenToFilenames, hasItem('/blog/tag/one/index.html'));
       });
+      it('AND render the page headline H1', async () => {
+        const groups = [
+          {tagSlug: 'one', blogPosts: [createBlogPost()]}
+        ];
+        /** @type string */
+        let writtenToFile = '';
+        /**
+         * @param _ {Filename}
+         * @param content {string}
+         * @return {Promise<void>}
+         */
+        const writeFile = async (_, content) => { writtenToFile = content; };
+        await renderAndWriteTagPages({writeFile})(groups, renderParams);
+        assertThat(writtenToFile, matchesPattern(/<h1.*>.*Tagged with #one.*<\/h1>/gms));
+      });
+      it('AND render the tag in the breadcrumb', async () => {
+        const groups = [
+          {tagSlug: 'one', blogPosts: [createBlogPost()]}
+        ];
+        /** @type string */
+        let writtenToFile = '';
+        /**
+         * @param _ {Filename}
+         * @param content {string}
+         * @return {Promise<void>}
+         */
+        const writeFile = async (_, content) => { writtenToFile = content; };
+        await renderAndWriteTagPages({writeFile})(groups, renderParams);
+        assertThat(writtenToFile, matchesPattern(/<nav class="breadcrumb">.*Tag &raquo;.*#one.*<\/nav>/gms));
+      });
+      it('AND render the post`s headlines as H2', async () => {
+        const groups = [
+          {tagSlug: 'one', blogPosts: [createBlogPost({headlineAsHtml: 'One tagged Blog-Post'})]}
+        ];
+        /** @type string */
+        let writtenToFile = '';
+        /**
+         * @param _ {Filename}
+         * @param content {string}
+         * @return {Promise<void>}
+         */
+        const writeFile = async (_, content) => { writtenToFile = content; };
+        await renderAndWriteTagPages({writeFile})(groups, renderParams);
+        assertThat(writtenToFile, matchesPattern(/<h2.*>.*One tagged Blog-Post.*<\/h2>/gms));
+      });
+      it('AND renders "tagged with: #one #two" under the post', async () => {
+        const groups = [
+          {tagSlug: 'one', blogPosts: [createBlogPost({tags: ['one', 'two']})]},
+        ];
+        /** @type string */
+        let writtenToFile = '';
+        /**
+         * @param _ {Filename}
+         * @param content {string}
+         * @return {Promise<void>}
+         */
+        const writeFile = async (_, content) => { writtenToFile = content; };
+        await renderAndWriteTagPages({writeFile})(groups, renderParams);
+        assertThat(writtenToFile, containsString('tagged with: #one #two'));
+      });
     });
   });
 });
+

--- a/src/render-blog/render-page.slow-spec.js
+++ b/src/render-blog/render-page.slow-spec.js
@@ -1,0 +1,50 @@
+import {describe, it} from '../test.js';
+import {assertThat, containsString, hasItem, matchesPattern} from 'hamjest';
+import {BlogPost} from "../blog-post/BlogPost.js";
+import {renderAndWriteTagPages} from "./render-page.js";
+
+// TODO THIS is really ugly, that we have to inject that every time.
+// Maybe intro a `DefaultRenderParameters.empty()` or something.
+const renderParams = {};
+
+const defaultRawBlogPostData = {
+  abstract: '',
+  abstractAsHtml: '',
+  bodyAsHtml: '',
+  hasAbstractOnly: false,
+  headline: '',
+  headlineAsHtml: '',
+  previewImage: '',
+  tags: [''],
+  dateCreated: '2000-01-01 10:00 CET',
+  slug: '',
+};
+/**
+ * @param overrideData {PlainObject}
+ * @return {BlogPost}
+ */
+const createBlogPost = (overrideData = {}) => {
+  return BlogPost.withRawData({...defaultRawBlogPostData, ...overrideData});
+}
+
+describe('Render blog pages', () => {
+  describe('GIVEN some blog posts WHEN rendering them', () => {
+    describe('THEN render a page per tag', () => {
+      it('AND write "one" tag`s page to "/blog/tag/one/index.html"', async () => {
+        const groups = [
+          {tagSlug: 'one', blogPosts: [createBlogPost()]}
+        ];
+        /** @type Filename[] */
+        const writtenToFilenames = [];
+        /**
+         * @param filename {Filename}
+         * @param _ {string}
+         * @return {Promise<void>}
+         */
+        const writeFile = async (filename, _) => { writtenToFilenames.push(filename); };
+        await renderAndWriteTagPages({writeFile})(groups, renderParams);
+        assertThat(writtenToFilenames, hasItem('/blog/tag/one/index.html'));
+      });
+    });
+  });
+});

--- a/src/render-tidbit/render-page.slow-spec.js
+++ b/src/render-tidbit/render-page.slow-spec.js
@@ -5,7 +5,7 @@ import {renderAndWriteTidbitPages, renderAndWriteTidbitsIndexPage} from './rende
 
 // TODO THIS is really ugly, that we have to inject that every time.
 // Maybe intro a `DefaultRenderParameters.empty()` or something.
-const renderParams = {navigationItems: [], groupedBlogPosts: {byTag: [], byMonth: []}, toReadableDate: () => ''};
+const renderParams = {navigationItems: [], groupedBlogPosts: {byTag: [], byMonth: []}};
 
 const defaultRawTidbitData = {
   abstract: '',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,3 +10,11 @@ type RelativeUrl = string; // e.g. /blog/2000/01/01-post/
 type PlainObject = {
   [key: string]: any;
 };
+
+type Slug = string;
+
+type Tag = {
+  value: string;
+  slug: Slug;
+}
+

--- a/templates/blog/_parts.html
+++ b/templates/blog/_parts.html
@@ -25,7 +25,7 @@
     <header>Top Blog Tags</header>
     <ol>
       {% for group in groups %}
-        <li><a href="/blog/tag/{{group.tag}}/">#{{group.tag}}</a></li>
+        <li><a href="/blog/tag/{{group.tagSlug}}/">#{{group.tagSlug}}</a></li>
       {% endfor %}
     </ol>
   </nav>

--- a/templates/blog/_parts.html
+++ b/templates/blog/_parts.html
@@ -10,7 +10,7 @@
       <div class="metadata">
         {{post.dateCreated | toReadableDate}}
         {% if post.tags.length > 0 %}
-          - tagged with: {% for tag in post.tags %}#{{tag}} {% endfor %}
+          - tagged with: {% for tag in post.tags %}#{{tag.value}} {% endfor %}
         {% endif %}
       </div>
     </header>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,14 +16,17 @@
     "src/_shared",
     "src/_deps",
     "src/types.d.ts",
+    "src/blog-post/types.d.ts",
     "src/BlogPost.d.ts",
     "src/blog-post/BlogPost.d.ts",
+//    "src/blog-post/group-blog-posts.js",
     "src/load-tidbit/Tidbit.d.ts",
     "src/load-tidbit/TidbitSourceFile.d.ts",
     "src/load-tidbit/load-tidbit.spec.js",
     "src/load-tidbit/load-tidbit.slow-spec.js",
     "src/load-tidbit/load-tidbit.js",
     "src/load-tidbit/sort-tidbit.js",
-    "src/render-*"
+    "src/render-tidbit",
+    "src/render-blog"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "src/load-tidbit/load-tidbit.slow-spec.js",
     "src/load-tidbit/load-tidbit.js",
     "src/load-tidbit/sort-tidbit.js",
-    "src/render-tidbit"
+    "src/render-*"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "src/blog-post/types.d.ts",
     "src/BlogPost.d.ts",
     "src/blog-post/BlogPost.d.ts",
-//    "src/blog-post/group-blog-posts.js",
+    "src/blog-post/group-blog-posts.js",
     "src/load-tidbit/Tidbit.d.ts",
     "src/load-tidbit/TidbitSourceFile.d.ts",
     "src/load-tidbit/load-tidbit.spec.js",


### PR DESCRIPTION
Enhance the blog tags object to not just be a string but like in tidbits make it `{value: "tag", slug: "tag"}`
To prepare for showing tags on the tidbits pages, align the blog tags first.